### PR TITLE
reCAPTCHA v2 support

### DIFF
--- a/recaptcharegister/web_ui.py
+++ b/recaptcharegister/web_ui.py
@@ -39,8 +39,9 @@ var RecaptchaOptions = {
 }""" % (self.theme, self.lang), type='text/javascript')
             captcha_js = captcha.displayhtml(
                 self.public_key, use_ssl=req.scheme=='https',
-                error='reCAPTCHA incorrect. Please try again.'
-            )
+                error='reCAPTCHA incorrect. Please try again.',
+                version=2
+            ) + captcha.load_script(version=2)
             # First Fieldset of the registration form XPath match
             xpath_match = '//form[@id="acctmgr_registerform"]/fieldset[1]'
             return stream | Transformer(xpath_match). \
@@ -130,8 +131,7 @@ var RecaptchaOptions = {
                 return handler
             self.check_config()
             if req.method == 'POST' and req.args.get('action') == 'create':
-                response = captcha.submit(
-                    req.args.get('recaptcha_challenge_field'),
+                response = captcha.v2submit(
                     req.args.get('recaptcha_response_field'),
                     self.private_key, req.remote_addr,
                 )

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name = 'TracRecaptchaRegister',
-    version = '0.3.2',
+    version = '0.3.3',
     author = 'Alejandro J. Cura, Pedro Algarvio',
     author_email = 'alecu@vortech.com.ar, ufs@ufsoft.org',
     url = 'http://trac-hacks.org/wiki/RecaptchaRegisterPlugin',
@@ -12,7 +12,7 @@ setup(
     install_requires = [
         'trac>=0.11',
         #'AccountManagerPlugin==0.2.1',
-        'recaptcha_client>=1.0.2',
+        'recaptcha_client>=2.0.1',
     ],
     entry_points = {
         'trac.plugins': [


### PR DESCRIPTION
reCAPTCHA v1 is no longer supported by Google.

This patch updates the TracRecaptchaRegister plugin to use API v2 via the updated version of the `recaptcha.client` module from RedHat found at https://github.com/redhat-infosec/python-recaptcha